### PR TITLE
Add an owner scene to each piece, and merge only pieces with the same owner

### DIFF
--- a/src/engine/mergegroup.cpp
+++ b/src/engine/mergegroup.cpp
@@ -52,6 +52,8 @@ QList<Palapeli::Piece*> Palapeli::MergeGroup::tryGrowMergeGroup(Palapeli::Piece*
 		{
 			foreach (Palapeli::Piece* logicalNeighbor, piece->logicalNeighbors())
 			{
+				if (piece->owner() != logicalNeighbor->owner())
+					continue;
 				//no need to check the located physical neighbors again
 				if (resultSet.contains(logicalNeighbor))
 					continue;

--- a/src/engine/piece.h
+++ b/src/engine/piece.h
@@ -29,6 +29,7 @@ namespace Palapeli
 {
 	class MovePieceInteractor;
 	class PieceVisuals;
+	class Scene;
 
 	class Piece : public Palapeli::GraphicsObject<Palapeli::PieceUserType>
 	{
@@ -86,6 +87,8 @@ namespace Palapeli
 			/// Place piece in a grid-cell, randomly or centered.
 			void setPlace(const QPointF& topLeft, int x, int y,
 					const QSizeF& area, bool random);
+			void setOwner(const Palapeli::Scene *s) { m_owner = s; }
+			const Palapeli::Scene *owner() const { return m_owner; }
 		Q_SIGNALS:
 			void moved(bool finished);
 			void replacedBy(Palapeli::Piece* newPiece);
@@ -109,6 +112,7 @@ namespace Palapeli
 			QPropertyAnimation* m_animator;
 			QPoint m_offset; // IDW test.
 
+			const Palapeli::Scene *m_owner {};
 			QList<int> m_representedAtomicPieces;
 			QList<Palapeli::Piece*> m_logicalNeighbors;
 			QSize m_atomicSize;

--- a/src/engine/scene.cpp
+++ b/src/engine/scene.cpp
@@ -41,6 +41,7 @@ Palapeli::Scene::Scene(QObject* parent)
 void Palapeli::Scene::addPieceToList(Palapeli::Piece* piece)
 {
 	m_pieces << piece;
+	piece->setOwner(this);
 }
 
 void Palapeli::Scene::addPieceItemsToScene()
@@ -54,6 +55,7 @@ void Palapeli::Scene::addPieceItemsToScene()
 void Palapeli::Scene::dispatchPieces(const QList<Palapeli::Piece*> &pieces)
 {
 	foreach (Palapeli::Piece * piece, pieces) {
+		piece->setOwner(nullptr);
 		piece->setSelected(false);
 		removeItem(piece);
 		m_pieces.removeAll(piece);
@@ -191,11 +193,10 @@ void Palapeli::Scene::pieceInstanceTransaction(const QList<Palapeli::Piece*>& de
 {
 	// qCDebug(PALAPELI_LOG) << "Scene::pieceInstanceTransaction(delete" << deletedPieces.count() << "add" << createdPieces.count();
 	const int oldPieceCount = m_pieces.count();
-	foreach (Palapeli::Piece* oldPiece, deletedPieces)
-		m_pieces.removeAll(oldPiece); //these pieces have been deleted by the caller
+	dispatchPieces(deletedPieces);
 	foreach (Palapeli::Piece* newPiece, createdPieces)
 	{
-		m_pieces << newPiece;
+		addPieceToList(newPiece);
 		connect(newPiece, &Piece::moved,
 			this, &Scene::pieceMoved);
 	}

--- a/src/engine/scene.h
+++ b/src/engine/scene.h
@@ -59,7 +59,7 @@ namespace Palapeli
 					{ return m_pieceAreaSize; }
 			void setPieceAreaSize(const QSizeF& pieceAreaSize)
 					{ m_pieceAreaSize = pieceAreaSize; }
-			QList<Palapeli::Piece*> pieces() { return m_pieces; }
+			const QList<Palapeli::Piece*> pieces() const { return m_pieces; }
 
 			void dispatchPieces(const QList<Palapeli::Piece*> &pcs);
 			void clearPieces();


### PR DESCRIPTION
This seems to solve a crash that sometimes occured when using piece holders.
One of the symptoms was that when trying to call removeAll on one of the
pieces to be removed, the return value from removeAll was zero, indicating that
no piece was removed from the list - so it must have been in a different list.
The code for merging pieces seems to have been unaware of the existence of
multiple scenes.